### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -26,11 +26,11 @@ function __slavic_current_folder
 end
 
 function __slavic_git_status_codes
-  echo (git status --porcelain ^/dev/null | sed -E 's/(^.{3}).*/\1/' | tr -d ' \n')
+  echo (git status --porcelain 2>/dev/null | sed -E 's/(^.{3}).*/\1/' | tr -d ' \n')
 end
 
 function __slavic_git_branch_name
-  echo (git rev-parse --abbrev-ref HEAD ^/dev/null)
+  echo (git rev-parse --abbrev-ref HEAD 2>/dev/null)
 end
 
 function __slavic_rainbow


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
